### PR TITLE
snl_tasks.py and custodian_tasks.py

### DIFF
--- a/mpworks/firetasks/boltztrap_tasks.py
+++ b/mpworks/firetasks/boltztrap_tasks.py
@@ -132,7 +132,7 @@ class BoltztrapRunTask(FireTaskBase, FWSerializable):
         bs = vr.get_band_structure(kpoints_filename=kpoints_loc)
         """
         filename = get_slug(
-            'JOB--' + fw_spec['mpsnl']['reduced_cell_formula_abc'] + '--'
+            'JOB--' + fw_spec['mpsnl'].structure.composition.reduced_formula + '--'
             + fw_spec['task_type'])
         with open(filename, 'w+') as f:
             f.write('')

--- a/mpworks/firetasks/controller_tasks.py
+++ b/mpworks/firetasks/controller_tasks.py
@@ -55,7 +55,7 @@ class AddEStructureTask(FireTaskBase, FWSerializable):
 
         type_name = 'GGA+U' if 'GGA+U' in fw_spec['prev_task_type'] else 'GGA'
 
-        snl = StructureNL.from_dict(fw_spec['mpsnl'])
+        snl = fw_spec['mpsnl']
         f = Composition(snl.structure.composition.reduced_formula).alphabetical_formula
 
         fws = []
@@ -154,7 +154,7 @@ class AddEStructureTask_old(FireTaskBase, FWSerializable):
             print 'Adding more runs...'
             type_name = 'GGA+U' if 'GGA+U' in fw_spec['prev_task_type'] else 'GGA'
 
-            snl = StructureNL.from_dict(fw_spec['mpsnl'])
+            snl = fw_spec['mpsnl']
             f = Composition(snl.structure.composition.reduced_formula).alphabetical_formula
 
             fws = []

--- a/mpworks/firetasks/custodian_task.py
+++ b/mpworks/firetasks/custodian_task.py
@@ -135,7 +135,7 @@ class VaspCustodianTask(FireTaskBase, FWSerializable):
 
     def _write_formula_file(self, fw_spec):
         filename = get_slug(
-            'JOB--' + fw_spec['mpsnl']['reduced_cell_formula_abc'] + '--'
+            'JOB--' + fw_spec['mpsnl'].structure.composition.reduced_formula + '--'
             + fw_spec['task_type'])
         with open(filename, 'w+') as f:
             f.write('')

--- a/mpworks/firetasks/custodian_task.py
+++ b/mpworks/firetasks/custodian_task.py
@@ -62,7 +62,7 @@ class VaspCustodianTask(FireTaskBase, FWSerializable):
 
     def __init__(self, parameters):
         self.update(parameters)
-        self.jobs = map(VaspJob.from_dict, self['jobs'])
+        self.jobs = self['jobs']
         dec = MontyDecoder()
         self.handlers = map(dec.process_decoded, self['handlers'])
         self.max_errors = self.get('max_errors', 1)

--- a/mpworks/firetasks/snl_tasks.py
+++ b/mpworks/firetasks/snl_tasks.py
@@ -21,7 +21,7 @@ class AddSNLTask(FireTaskBase, FWSerializable):
 
     def run_task(self, fw_spec):
         sma = SNLMongoAdapter.auto_load()
-        snl = StructureNL.from_dict(fw_spec['snl'])
+        snl = fw_spec['snl']
         mpsnl, snlgroup_id, spec_group = sma.add_snl(snl)
         mod_spec = [{"_push": {"run_tags": "species_group={}".format(spec_group)}}] if spec_group else None
 

--- a/mpworks/firetasks/vasp_io_tasks.py
+++ b/mpworks/firetasks/vasp_io_tasks.py
@@ -42,10 +42,10 @@ class VaspWriterTask(FireTaskBase, FWSerializable):
     _fw_name = "Vasp Writer Task"
 
     def run_task(self, fw_spec):
-        Incar.from_dict(fw_spec['vasp']['incar']).write_file('INCAR')
-        Poscar.from_dict(fw_spec['vasp']['poscar']).write_file('POSCAR')
-        Potcar.from_dict(fw_spec['vasp']['potcar']).write_file('POTCAR')
-        Kpoints.from_dict(fw_spec['vasp']['kpoints']).write_file('KPOINTS')
+        fw_spec['vasp']['incar'].write_file('INCAR')
+        fw_spec['vasp']['poscar'].write_file('POSCAR')
+        fw_spec['vasp']['potcar'].write_file('POTCAR')
+        fw_spec['vasp']['kpoints'].write_file('KPOINTS')
 
 
 class VaspCopyTask(FireTaskBase, FWSerializable):


### PR DESCRIPTION
Was having an issue with "lpad rerun_fws", traceback below:

  File "/global/u1/m/montoyjh/jhm_vasp/codes/fireworks/fireworks/core/firework.py", line 51, in __call__
    o = abc.ABCMeta.__call__(cls, *args, **kwargs)
  File "/global/u1/m/montoyjh/jhm_vasp/codes/MPWorks/mpworks/firetasks/custodian_task.py", line 65, in __init__
    self.jobs = map(VaspJob.from_dict, self['jobs'])
  File "/global/u1/m/montoyjh/jhm_vasp/codes/custodian/custodian/vasp/jobs.py", line 307, in from_dict
    vis = MontyDecoder().process_decoded(d["default_vasp_input_set"])
TypeError: 'VaspJob' object has no attribute '__getitem__'

Seems like self['jobs'] in VaspCustodianTask is a list of VaspJob objects, rather than dictionaries (similarly, run_task in snl_tasks.py tries to construct an snl from a dict when fw_spec['snl'] is an object), so I changed those two lines.  Not sure whether there's a deeper problem that might need to be addressed, but seemed to fix the issue.