### PR TITLE
use BoltzTrapRunner and Analyzer from pymatgen

### DIFF
--- a/mpworks/firetasks/boltztrap_tasks.py
+++ b/mpworks/firetasks/boltztrap_tasks.py
@@ -121,7 +121,7 @@ class BoltztrapRunTask(FireTaskBase, FWSerializable):
 
     def run_task(self, fw_spec):
         # import here to prevent import errors in bigger MPCollab
-        from mpcollab.thermoelectrics.boltztrap_TE import BoltztrapAnalyzerTE, BoltzSPB
+        from mpcollab.thermoelectrics.boltztrap_TE import BoltzSPB
         # get the band structure and nelect from files
         """
         prev_dir = get_loc(fw_spec['prev_vasp_dir'])
@@ -195,9 +195,7 @@ class BoltztrapRunTask(FireTaskBase, FWSerializable):
             """
 
             # now for the "sanitized" data
-            te_analyzer = BoltztrapAnalyzerTE.from_BoltztrapAnalyzer(bta)
-
-            ted = te_analyzer.as_dict()
+            ted = bta.as_dict()
             del ted['seebeck']
             del ted['hall']
             del ted['kappa']
@@ -211,8 +209,8 @@ class BoltztrapRunTask(FireTaskBase, FWSerializable):
             ted['dir_name'] = get_block_part(dir)
             ted['task_id'] = m_task['task_id']
 
-            ted['pf_doping'] = te_analyzer.get_power_factor(tau=self.TAU).as_dict()
-            ted['zt_doping'] = te_analyzer.get_ZT(kappal=self.KAPPAL, tau=self.TAU).as_dict()
+            ted['pf_doping'] = bta.get_power_factor(output='tensor', relaxation_time=self.TAU)
+            ted['zt_doping'] = bta.get_zt(output='tensor', relaxation_time=self.TAU, kl=self.KAPPAL)
 
             ted['pf_eigs'] = self.get_eigs(ted, 'pf_doping')
             ted['pf_best'] = self.get_extreme(ted, 'pf_eigs')

--- a/mpworks/firetasks/boltztrap_tasks.py
+++ b/mpworks/firetasks/boltztrap_tasks.py
@@ -104,7 +104,7 @@ class BoltztrapRunTask(FireTaskBase, FWSerializable):
                                     max_val = val
                                     max_temp = float(t)
                                     max_dope = d['doping'][te_type][didx]
-                                    max_mu = d['mu_doping'][te_type][t][didx]
+                                    max_mu = d['mu_doping'][te_type][str(t)][didx]
 
                                 isotropic = evs['isotropic']
                 data[te_type] = {'value': max_val, 'temperature': max_temp, 'doping': max_dope, 'mu': max_mu, 'isotropic': isotropic}


### PR DESCRIPTION
This pull request moves MPWorks away from the custom boltztrap_TE module to the official code in pymatgen. It currently is able to successfully complete a BoltzTrap task but throws the warning

`COULD NOT GET FINE MESH DATA`

since the `BoltzSBP` part of `boltztrap_task` has not been ported, yet. See
https://github.com/materialsproject/MPWorks/blob/0f85eb6dc536cb37cc47323509c6e024ec86938a/mpworks/firetasks/boltztrap_tasks.py#L238-L259

@hautierg @computron 